### PR TITLE
Using pydrive with user credentials for authenticated download

### DIFF
--- a/download_ffhq.py
+++ b/download_ffhq.py
@@ -28,8 +28,8 @@ import argparse
 import itertools
 import shutil
 from collections import OrderedDict, defaultdict
-from pydrive.auth import GoogleAuth
-from pydrive.drive import GoogleDrive
+from pydrive2.auth import GoogleAuth
+from pydrive2.drive import GoogleDrive
 
 PIL.ImageFile.LOAD_TRUNCATED_IMAGES = True # avoid "Decompressed Data Too Large" error
 


### PR DESCRIPTION
Unfortunately, when using your code, an anonymous download is performed and I tried several consecutive days, I always got an exceeded quota error making me unable to download the dataset.

This pull requests, which uses code adapted from the [FFHQ-Aging](https://github.com/royorel/FFHQ-Aging-Dataset) repo is using user credentials for downloading the dataset. 

The only requirement is to follow the [pydrive quickstart](https://pythonhosted.org/PyDrive/quickstart.html#authentication) for getting the `client_secrets.json` file placed in the same directory than `download_ffhq.py` and you can then indicate you want to use pydrive google authentication by appending the `--pydrive` command line option.

So for example, for downloading the 1024x1024 images, you simply :

```
python3 download_ffhq.py -i --pydrive
```

In the code, several attempts are tried to download a file. Without that code, inspired by yours, I got some `httplib2.error.ServerNotFoundError: Unable to find the server at www.googleapis.com` being raised. Apparently, retrying the download a second time and the exception is not raised. 

I only tested the download of the images (the command line above) but as the other downloads go through the `download_files` function, I hope it works as well for the other downloads.
